### PR TITLE
feat: downgrade module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/aminofox/zentrox
 
-go 1.24.5
+go 1.22


### PR DESCRIPTION
Go 1.24.x is not yet popular and is not available on most CI/CD pipelines, package managers (brew, apt, choco, …). To ensure compatibility and ease of installation, we downgrade to a more stable & popular version (e.g. 1.22.x or 1.23.x).